### PR TITLE
Add DIR_LS

### DIFF
--- a/Firmware/Hub-Mega2560/Hub-Mega2560.ino
+++ b/Firmware/Hub-Mega2560/Hub-Mega2560.ino
@@ -1434,6 +1434,7 @@ void comProcessCMD() {
             }
             dir.close();
             serBuffer[0] = count;
+            serLen = length;
         }
 
         pushPacket(HUB_DIR_LS, -1);

--- a/Firmware/Hub-Mega2560/Hub-Mega2560.ino
+++ b/Firmware/Hub-Mega2560/Hub-Mega2560.ino
@@ -1418,7 +1418,7 @@ void comProcessCMD() {
         // Send back file size
         length = hubFile[comInBuffer[0]].size();
         memcpy(serBuffer, (char*)&length, 4); serLen = 4;
-        pushPacket(HUB_FILE_OPEN, comInBuffer[0]);
+        pushPacket(HUB_FILE_OPEN, -1);
         break;
 
     case HUB_FILE_SEEK:


### PR DESCRIPTION
Add a dir ls implementation.

Please notice that i used the parameter different than originally documented (as it makes more sense).

The MR includes  a fix for teh return value of FILE_OPEN. From the library code it is clear that the return code is not boud to the file ID (like for the network sockets), but always requests -1.